### PR TITLE
Typo fixup in startMining function and version bump

### DIFF
--- a/coinhive/build.gradle
+++ b/coinhive/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/theapache64/Coine-Hive-Android-SDK'
     gitUrl = 'https://github.com/theapache64/Coine-Hive-Android-SDK'
 
-    libraryVersion = '1.0.6'
+    libraryVersion = '1.0.7'
 
     developerId = 'theapache64'
     developerName = 'theapache64'
@@ -38,7 +38,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 25
         versionCode 7
-        versionName "1.0.6"
+        versionName "1.0.7"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/coinhive/src/main/java/com/theah64/coinhive/BaseCoinHiveActivity.java
+++ b/coinhive/src/main/java/com/theah64/coinhive/BaseCoinHiveActivity.java
@@ -53,7 +53,7 @@ public class BaseCoinHiveActivity extends AppCompatActivity {
     }
 
     public void startMining() {
-        wvCoinHive.loadUrl("javascript:stopMining()");
+        wvCoinHive.loadUrl("javascript:startMining()");
     }
 
 


### PR DESCRIPTION
There was a typo where javascript stopMining() function was called in
startMining CoinHiveBaseActivity function. This probably needs to be
consistent as it provides direct functionality.

This is probably the reason for #4 